### PR TITLE
fix: Don't recursively import scripts from EXT:backend

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -3,7 +3,7 @@
 return [
     'file_WvFileCleanupCleanup' => [
         'parent' => 'file',
-        'access' => 'user,group',
+        'access' => 'user',
         'workspaces' => 'online,custom',
         'path' => '/file/wvfilecleanup',
         'icon' => 'EXT:wv_file_cleanup/Resources/Public/Icons/module-cleanup.svg',

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -11,9 +11,6 @@ return [
         'backend.module',
     ],
     'imports' => [
-        // recursive definition, all *.js files in this folder are import-mapped
-        // trailing slash is required per importmap-specification
-        '@typo3/backend/' => 'EXT:backend/Resources/Public/JavaScript/',
         '@WebVision/WvFileCleanup/' => 'EXT:wv_file_cleanup/Resources/Public/JavaScript/',
     ]
 ];

--- a/Resources/Private/Templates/Cleanup/Index.html
+++ b/Resources/Private/Templates/Cleanup/Index.html
@@ -56,6 +56,9 @@
                                 </f:else>
                                 </f:if>
                             </td>
+                            <td nowrap="nowrap" class="col-path">
+                                {file.path}
+                            </td>
                             <td nowrap="nowrap" class="col-title">
                                 {file.name}
                                 <f:if condition="{checkboxes.displayThumbs.checked}">
@@ -64,9 +67,6 @@
                                         <f:image image="{file.resource}" maxWidth="64" maxHeight="43" />
                                     </f:if>
                                 </f:if>
-                            </td>
-                            <td nowrap="nowrap" class="col-path">
-                                {file.path}
                             </td>
                             <td nowrap="nowrap">{file.extension}</td>
                             <td nowrap="nowrap">{file.lastModified}</td>

--- a/Resources/Private/Templates/Cleanup/Index.html
+++ b/Resources/Private/Templates/Cleanup/Index.html
@@ -57,7 +57,7 @@
                                 </f:if>
                             </td>
                             <td nowrap="nowrap" class="col-title">
-                                {file.name->f:format.crop( maxCharacters:30 )}
+                                {file.name}
                                 <f:if condition="{checkboxes.displayThumbs.checked}">
                                     <f:if condition="{file.isImage}">
                                         <br>


### PR DESCRIPTION
This is unneeded and breaks overrides from other extensions